### PR TITLE
fix: enable cancel button in active subscriptions

### DIFF
--- a/src/components/subscriptions/ItemActions.tsx
+++ b/src/components/subscriptions/ItemActions.tsx
@@ -36,7 +36,7 @@ export const ItemActions: FunctionalComponent<Props> = props => {
       <slot name={`row-${props.row}-actions-cancel`}>
         <LinkButton
           href={`${tokenURL}&sub_cancel=true`}
-          disabled={isDisabled}
+          disabled={!props.item.is_active}
           loaded={Boolean(props.i18n)}
           text={() => props.i18n.cancel}
           theme="error"


### PR DESCRIPTION
Use the correct condition to toggle the disabled state on and off based on whether the subscription is active or not, regardless of template_config.allow_next_date_modification value.