### PR TITLE
fix: Enables subscription "update billing" button.

### DIFF
--- a/src/components/subscriptions/ItemActions.tsx
+++ b/src/components/subscriptions/ItemActions.tsx
@@ -14,10 +14,6 @@ interface Props {
 export const ItemActions: FunctionalComponent<Props> = props => {
   const tokenURL = props.item._links["fx:sub_token_url"].href;
 
-  const isDisabled =
-    !props.item._embedded.template_config.allow_next_date_modification ||
-    !props.item.is_active;
-
   return (
     <div class="flex flex-wrap justify-between -mx-s sm:flex-no-wrap sm:justify-start">
       <slot name={`row-${props.row}-actions-prepend`} />
@@ -25,7 +21,7 @@ export const ItemActions: FunctionalComponent<Props> = props => {
       <slot name={`row-${props.row}-actions-update-billing`}>
         <LinkButton
           href={`${tokenURL}&cart=checkout&sub_restart=auto`}
-          disabled={isDisabled}
+          disabled={!props.item.is_active}
           loaded={Boolean(props.i18n)}
           text={() => props.i18n.update}
           icon="credit-card"


### PR DESCRIPTION
The "update" button should be enabled even if the next-date modification
is disabled for a subscription.

Closes #3