### PR TITLE
Improvements to the cancelled state in subscriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxy.io/customer-portal",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/subscriptions/FrequencyPicker.tsx
+++ b/src/components/subscriptions/FrequencyPicker.tsx
@@ -1,6 +1,7 @@
 import { FunctionalComponent, h } from "@stencil/core";
 import { Skeleton } from "../Skeleton";
 import { Subscription } from "../../assets/types/Subscription";
+import { isCancelled } from "./utils";
 
 interface Props {
   item: Subscription;
@@ -34,15 +35,10 @@ function renderItems({ item, i18n }: Props, root: HTMLElement) {
 export const FrequencyPicker: FunctionalComponent<Props> = props => {
   const config = props.item._embedded.template_config;
   const values = config.allow_frequency_modification;
-
-  const isReadonly =
-    !values ||
-    !props.item.is_active ||
-    values.length === 0 ||
-    props.i18n === null;
+  const readonly = !values || !values.length || !props.i18n || isCancelled(props.item);
 
   return (
-    <div class={{ "pb-s sm:pb-0": !isReadonly }}>
+    <div class={{ "pb-s sm:pb-0": !readonly }}>
       <div class="text-s text-contrast-50 sm:hidden">
         <Skeleton
           loaded={Boolean(props.i18n)}
@@ -53,7 +49,7 @@ export const FrequencyPicker: FunctionalComponent<Props> = props => {
         class="w-full"
         data-e2e="fld-freq"
         data-theme="foxy-subscriptions"
-        readonly={isReadonly}
+        readonly={readonly}
         value={props.item.frequency}
         renderer={root => renderItems(props, root)}
         onChange={event => props.onChange(event)}

--- a/src/components/subscriptions/ItemActions.tsx
+++ b/src/components/subscriptions/ItemActions.tsx
@@ -1,6 +1,7 @@
 import { FunctionalComponent, h } from "@stencil/core";
 import { LinkButton } from "../LinkButton";
 import { Subscription } from "../../assets/types/Subscription";
+import { isCancelled } from "./utils";
 
 interface Props {
   row: number;
@@ -13,6 +14,7 @@ interface Props {
 
 export const ItemActions: FunctionalComponent<Props> = props => {
   const tokenURL = props.item._links["fx:sub_token_url"].href;
+  const disabled = isCancelled(props.item);
 
   return (
     <div class="flex flex-wrap justify-between -mx-s sm:flex-no-wrap sm:justify-start">
@@ -21,7 +23,7 @@ export const ItemActions: FunctionalComponent<Props> = props => {
       <slot name={`row-${props.row}-actions-update-billing`}>
         <LinkButton
           href={`${tokenURL}&cart=checkout&sub_restart=auto`}
-          disabled={!props.item.is_active}
+          disabled={disabled}
           loaded={Boolean(props.i18n)}
           text={() => props.i18n.update}
           icon="credit-card"
@@ -32,7 +34,7 @@ export const ItemActions: FunctionalComponent<Props> = props => {
       <slot name={`row-${props.row}-actions-cancel`}>
         <LinkButton
           href={`${tokenURL}&sub_cancel=true`}
-          disabled={!props.item.is_active}
+          disabled={disabled}
           loaded={Boolean(props.i18n)}
           text={() => props.i18n.cancel}
           theme="error"

--- a/src/components/subscriptions/NextDatePicker.tsx
+++ b/src/components/subscriptions/NextDatePicker.tsx
@@ -1,6 +1,7 @@
 import { FunctionalComponent, h } from "@stencil/core";
 import { Subscription } from "../../assets/types/Subscription";
 import { Skeleton } from "../Skeleton";
+import { isCancelled } from "./utils";
 
 interface Props {
   onChange: (item: Subscription, event: Event) => any;
@@ -20,21 +21,21 @@ export function formatDate(date: Date) {
 }
 
 export const NextDatePicker: FunctionalComponent<Props> = props => {
-  const isReadonly =
-    !props.item._embedded.template_config.allow_next_date_modification ||
-    !props.item.is_active;
+  const cancelled = isCancelled(props.item);
+  const disabled = !props.item._embedded.template_config.allow_next_date_modification;
+  const readonly = disabled || cancelled;
 
   return (
-    <div class={{ "pb-s sm:pb-0": !isReadonly }}>
+    <div class={{ "pb-s sm:pb-0": !readonly }}>
       <div class="text-s text-contrast-50 sm:hidden">
         <Skeleton loaded={Boolean(props.i18n)} text={() => props.i18n.picker} />
       </div>
       <vaadin-date-picker
         data-e2e="fld-date"
         data-theme="foxy-subscriptions"
-        readonly={isReadonly}
+        readonly={readonly}
         class="w-full sm:w-auto sm:mr-s"
-        min={isReadonly ? undefined : formatDate(new Date())}
+        min={readonly ? undefined : formatDate(new Date())}
         i18n={Boolean(props.i18n) ? props.i18n.pickerI18n : undefined}
         value={formatDate(new Date(props.item.next_transaction_date))}
         onChange={(e: Event) => props.onChange(props.item, e)}

--- a/src/components/subscriptions/StatusSummary.tsx
+++ b/src/components/subscriptions/StatusSummary.tsx
@@ -1,6 +1,7 @@
 import { FunctionalComponent, h } from "@stencil/core";
 import { Subscription } from "../../assets/types/Subscription";
 import { Skeleton } from "../Skeleton";
+import { isCancelled } from "./utils";
 
 interface Props {
   item: Subscription;
@@ -14,8 +15,8 @@ export const StatusSummary: FunctionalComponent<Props> = props => (
     <div
       class={{
         "text-s mr-s": true,
-        "text-success": props.item.is_active,
-        "text-contrast-50": !props.item.is_active
+        "text-success": !isCancelled(props.item),
+        "text-contrast-50": isCancelled(props.item)
       }}
     >
       ●

--- a/src/components/subscriptions/subscriptions.e2e.ts
+++ b/src/components/subscriptions/subscriptions.e2e.ts
@@ -4,6 +4,7 @@ import { interceptAPIRequests } from "../../assets/utils/interceptAPIRequests";
 import { E2EElement } from "@stencil/core/dist/testing";
 import { Subscription } from "../../assets/types/Subscription";
 import { i18nProvider } from "./i18n";
+import { isCancelled } from "./utils";
 import { formatDate } from "./NextDatePicker";
 
 const tag = "foxy-subscriptions";
@@ -138,11 +139,13 @@ async function shouldDisplay(row: E2EElement, item: Subscription) {
     formatDate(new Date(item.next_transaction_date))
   );
 
-  expect(await updateLink.getProperty("href")).toBe(
-    `${item._links["fx:sub_token_url"].href.toLowerCase()}&cart=checkout&sub_restart=auto`
-  );
+  if (!isCancelled(item)) {
+    expect(await updateLink.getProperty("href")).toBe(
+      `${item._links["fx:sub_token_url"].href.toLowerCase()}&cart=checkout&sub_restart=auto`
+    );
 
-  expect(await cancelLink.getProperty("href")).toBe(
-    `${item._links["fx:sub_token_url"].href.toLowerCase()}&sub_cancel=true`
-  );
+    expect(await cancelLink.getProperty("href")).toBe(
+      `${item._links["fx:sub_token_url"].href.toLowerCase()}&sub_cancel=true`
+    );
+  }
 }

--- a/src/components/subscriptions/subscriptions.e2e.ts
+++ b/src/components/subscriptions/subscriptions.e2e.ts
@@ -139,7 +139,7 @@ async function shouldDisplay(row: E2EElement, item: Subscription) {
   );
 
   expect(await updateLink.getProperty("href")).toBe(
-    `${item._links["fx:sub_token_url"].href.toLowerCase()}&cart=checkout`
+    `${item._links["fx:sub_token_url"].href.toLowerCase()}&cart=checkout&sub_restart=auto`
   );
 
   expect(await cancelLink.getProperty("href")).toBe(

--- a/src/components/subscriptions/utils.ts
+++ b/src/components/subscriptions/utils.ts
@@ -1,0 +1,10 @@
+import { Subscription } from "../../assets/types/Subscription";
+
+export function isCancelled(subscription: Subscription) {
+  if (!subscription.end_date) return false;
+
+  const endsWithNextPayment = subscription.end_date === subscription.next_transaction_date;
+  const endsWithinADay = new Date(subscription.end_date).getTime() - Date.now() <= 86400000;
+
+  return !subscription.is_active || endsWithinADay || endsWithNextPayment;
+}


### PR DESCRIPTION
If a subscription has an `end_date` and if it's within a day from now or if `end_date === next_transaction_date`, disable the cancel/update buttons and the frequency/next date modification controls.