### PR TITLE
docs: Adding an example language override.

### DIFF
--- a/src/demos/foxycart.html
+++ b/src/demos/foxycart.html
@@ -92,6 +92,13 @@
         passwordInput.setProperties({ value: "asdfasdf" });
         signInButton.focus();
       }
+
+      // Example modifying the default language strings
+      document.querySelector('foxy-plugin-warning').locale = {
+        "en": {
+          "warning": "Warning: It appears you're using a browser extension that's modifying your keyboard input. If you notice problems entering text in our customer portal, please try disabling any extensions that hijack your keyboard input, and let us know you saw this message so we can contact the extension developer (or submit a patch, if the source is on github)."
+        }
+      };
     });
 
   </script>


### PR DESCRIPTION
Adding a quick example showing how to override language strings.