### PR TITLE
Fix inactive address component's country & region inputs when FC loading is delayed

### DIFF
--- a/src/components/address/address.e2e.ts
+++ b/src/components/address/address.e2e.ts
@@ -8,6 +8,7 @@ import { replaceText } from "../../assets/utils/replaceText";
 import { usePage } from "../../assets/utils/usePage";
 import { interceptAPIRequests } from "../../assets/utils/interceptAPIRequests";
 import { Address } from "../../assets/types/Address";
+import { FC } from "./mocks/fc";
 
 describe("HTMLFoxyAddressElement", () => {
   const templates = [
@@ -155,6 +156,69 @@ describe("HTMLFoxyAddressElement", () => {
 
         await shouldRenderAddress(page, newAddress);
         shouldMatch(db.shippingAddress, newAddress);
+      });
+    });
+  });
+
+  describe("authorized: loads data from window.FC", () => {
+    it("loads immediately when it's available", async () => {
+      await interceptAPIRequests(async ({ signIn, page, url, db }) => {
+        const html = `
+          <script>window.FC = JSON.parse(\`${JSON.stringify(FC)}\`)</script>
+          <foxy-address endpoint="${url}"></foxy-address>
+        `;
+
+        db.billingAddress.country = "US";
+        db.billingAddress.region = "TX";
+
+        await signIn();
+        await page.setContent(html);
+        await page.waitForChanges();
+        await click(page, "foxy-address >>> [data-e2e=toggle]");
+
+        const country = await page.find("foxy-address >>> [data-e2e=country]");
+        const region = await page.find("foxy-address >>> [data-e2e=region]");
+
+        expect(await country.getProperty("items")).toEqual([
+          { value: "US", label: "United States" }
+        ]);
+
+        expect(await region.getProperty("items")).toEqual([
+          { value: "TX", label: "Texas" }
+        ]);
+      });
+    });
+
+    it("loads whenever it becomes available later if not present immediately", async () => {
+      await interceptAPIRequests(async ({ signIn, page, url, db }) => {
+        const html = `<foxy-address endpoint="${url}"></foxy-address>`;
+
+        db.billingAddress.country = "US";
+        db.billingAddress.region = "TX";
+
+        await signIn();
+        await page.setContent(html);
+        await page.waitForChanges();
+
+        await page.waitFor(3000);
+        await page.evaluate((fcMock: any) => {
+          const onLoad = window.FC?.onLoad;
+          window.FC = fcMock;
+          if (Boolean(onLoad)) onLoad();
+        }, FC);
+
+        await click(page, "foxy-address >>> [data-e2e=toggle]");
+
+        const country = await page.find("foxy-address >>> [data-e2e=country]");
+        const region = await page.find("foxy-address >>> [data-e2e=region]");
+
+        expect(await country.getProperty("items")).toEqual([
+          { value: "US", label: "United States" }
+        ]);
+
+        expect(await region.getProperty("items")).toEqual([
+          { value: "TX", label: "Texas" }
+        ]);
       });
     });
   });

--- a/src/components/address/mocks/fc.ts
+++ b/src/components/address/mocks/fc.ts
@@ -1,0 +1,32 @@
+export const FC = {
+  json: {
+    config: {
+      locations_billing: {},
+      locations: {
+        US: {
+          cn: "United States",
+          cc2: "US",
+          cc3: "USA",
+          ccnum: "840",
+          alt: ["USA", "United States of America", "America"],
+          boost: 4.5,
+          r: {
+            options: {
+              TX: { n: "Texas", c: "TX", alt: [], boost: 1, active: true }
+            },
+            req: true,
+            lang: "state"
+          },
+          pc: {
+            req: true,
+            lang: "zipcode",
+            search: true,
+            int: false,
+            regex: "^\\\\d{5}$|^\\\\d{5}-?\\\\d{4}$"
+          },
+          active: true
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
This PR fixes a few issues that prevented `foxy-address` from loading data from `window.FC` when it was initialized after the element itself. A couple of extra tests have also been added to make sure this functionality works regardless of when `window.FC` becomes available.