### PR TITLE
Allow additional customization of subscription cancel links

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -4,6 +4,8 @@ interface Props {
   title?: string;
   href?: string;
   text?: string;
+  size?: "m" | "s";
+  color?: "secondary" | "body";
 }
 
 export const Link: FunctionalComponent<Props> = props => (
@@ -13,7 +15,11 @@ export const Link: FunctionalComponent<Props> = props => (
     target="_blank"
     rel="nofollow noreferrer noopener"
     class={{
-      "px-xs -mx-xs inline-block text-body rounded-m leading-s font-medium text-m hover:no-underline focus:outline-none": true,
+      "text-s": props.size === "s",
+      "text-m": !Boolean(props.size) || props.size === "m",
+      "text-body": !Boolean(props.color) || props.color === "body",
+      "text-secondary": props.color === "secondary",
+      "px-xs -mx-xs inline-block rounded-m leading-s font-medium hover:no-underline focus:outline-none": true,
       "transition duration-150 hover:text-primary focus:shadow-outline": Boolean(
         props?.href
       )

--- a/src/components/subscription/subscription.tsx
+++ b/src/components/subscription/subscription.tsx
@@ -369,6 +369,8 @@ export class Subscription implements Mixins {
                   <Link
                     href={getCancelUrl(this._subscription)}
                     text={this.i18n.cancelSubscription}
+                    size="s"
+                    color="secondary"
                   />
                 </div>
               )}

--- a/src/components/subscription/subscription.tsx
+++ b/src/components/subscription/subscription.tsx
@@ -366,12 +366,14 @@ export class Subscription implements Mixins {
 
               {this._subscription.is_active && (
                 <div class="px-m pb-m pt-m -mt-xs text-right">
-                  <Link
-                    href={getCancelUrl(this._subscription)}
-                    text={this.i18n.cancelSubscription}
-                    size="s"
-                    color="secondary"
-                  />
+                  <slot name="action-cancel">
+                    <Link
+                      href={getCancelUrl(this._subscription)}
+                      text={this.i18n.cancelSubscription}
+                      size="s"
+                      color="secondary"
+                    />
+                  </slot>
                 </div>
               )}
             </div>

--- a/src/components/subscription/subscription.tsx
+++ b/src/components/subscription/subscription.tsx
@@ -364,7 +364,7 @@ export class Subscription implements Mixins {
                 <slot name="actions" />
               </div>
 
-              {this._isNextDateEditable && this._subscription.is_active && (
+              {this._subscription.is_active && (
                 <div class="px-m pb-m pt-m -mt-xs text-right">
                   <Link
                     href={getCancelUrl(this._subscription)}

--- a/src/demos/advanced.html
+++ b/src/demos/advanced.html
@@ -88,11 +88,13 @@
           </div>
         </foxy-transactions>
 
-        <foxy-subscriptions slot="subscriptions" cols="5" locale="en">
-          <span slot="header-4">Status</span>
-          <div v-for="(subscription, index) in customer._embedded['fx:subscriptions']" :slot="'row-' + index + '-col-4'" :key="index">
-            <span v-if="subscription.is_active" class="text-green-500">Active</span>
-            <span v-else class="text-red-500">Inactive</span>
+      <foxy-subscriptions slot="subscriptions">
+        <div v-for="(subscription, index) in customer._embedded['fx:subscriptions']" :slot="index" :key="index">
+          <foxy-subscription>
+            <div slot="action-cancel" class="text-secondary text-s">
+              Please <a href="/contact" class="hover:underline">contact us</a> to cancel
+            </div>
+          </foxy-subscription>
           </div>
         </foxy-subscriptions>
       </foxy-customer-portal>

--- a/src/demos/subscription.html
+++ b/src/demos/subscription.html
@@ -14,11 +14,33 @@
     html {
       background: var(--foxy-shade-10pct);
     }
+
+    .text-s {
+      font-size: var(--foxy-font-size-s);
+    }
+
+    .text-secondary {
+      color: var(--foxy-secondary-text-color);
+    }
   </style>
 
-  <div class="m-4 rounded-lg shadow-lg overflow-hidden">
-    <foxy-subscription endpoint="http://localhost:5000"></foxy-subscription>
-  </div>
+  <figure class="m-4">
+    <figcaption class="mb-2">Default</figcaption>
+    <div class="rounded-lg shadow-lg overflow-hidden">
+      <foxy-subscription endpoint="http://localhost:5000"></foxy-subscription>
+    </div>
+  </figure>
+
+  <figure class="m-4">
+    <figcaption class="mb-2">With custom cancel action</figcaption>
+    <div class="rounded-lg shadow-lg overflow-hidden">
+      <foxy-subscription endpoint="http://localhost:5000">
+        <div slot="action-cancel" class="text-secondary text-s">
+          Please <a href="/contact" class="hover:underline">contact us</a> to cancel
+        </div>
+      </foxy-subscription>
+    </div>
+  </figure>
 </body>
 
 </html>


### PR DESCRIPTION
This PR:

- fixes an issue where subscription component wouldn't display the cancel link if the next date modification was disabled in configuration
- updates the cancel link's font style
- adds a new slot named `action-cancel` to the `foxy-subscription` element
- adds an example of `action-cancel` usage to the standalone subscription demo page