### PR TITLE
Make top nav customizable

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -66,13 +66,6 @@ export namespace Components {
          */
         "locale": any;
         /**
-          * List of links to add to the top nav. You can either use Markdown (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`) to avoid writing extra JS or assign this property an array where each item is an object with properties `href` for URL and `caption` for the display text (both string).
-         */
-        "navLinks": string | {
-            href: string;
-            caption: string;
-        }[];
-        /**
           * Enables hash-based routing.
          */
         "router": boolean;
@@ -87,6 +80,13 @@ export namespace Components {
             zoom: Record<"default_billing_address" | "default_shipping_address" | "subscriptions" | "transactions" | "default_payment_method", true>;
             sso: true;
         }>>) => Promise<void>;
+        /**
+          * List of links to add to the top nav. You can either use Markdown (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`) to avoid writing extra JS or assign this property an array where each item is an object with properties `href` for URL and `caption` for the display text (both string).
+         */
+        "tabs": string | {
+            href: string;
+            caption: string;
+        }[];
     }
     interface FoxyPluginWarning {
         /**
@@ -322,13 +322,6 @@ declare namespace LocalJSX {
          */
         "locale"?: any;
         /**
-          * List of links to add to the top nav. You can either use Markdown (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`) to avoid writing extra JS or assign this property an array where each item is an object with properties `href` for URL and `caption` for the display text (both string).
-         */
-        "navLinks"?: string | {
-            href: string;
-            caption: string;
-        }[];
-        /**
           * Fired when component becomes ready to be interacted with.
          */
         "onReady"?: (event: CustomEvent<void>) => void;
@@ -352,6 +345,13 @@ declare namespace LocalJSX {
           * Prefix for routes and other top-level identifiers.
          */
         "scope"?: string;
+        /**
+          * List of links to add to the top nav. You can either use Markdown (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`) to avoid writing extra JS or assign this property an array where each item is an object with properties `href` for URL and `caption` for the display text (both string).
+         */
+        "tabs"?: string | {
+            href: string;
+            caption: string;
+        }[];
     }
     interface FoxyPluginWarning {
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -7,6 +7,7 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { AddressType, } from "./components/address/types";
 import { FullGetResponse, GetRequest, GetResponse, } from "./api";
+import { Tab, } from "./components/customer-portal/types";
 export namespace Components {
     interface FoxyAddress {
         /**
@@ -81,12 +82,9 @@ export namespace Components {
             sso: true;
         }>>) => Promise<void>;
         /**
-          * List of links to add to the top nav. You can either use Markdown (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`) to avoid writing extra JS or assign this property an array where each item is an object with properties `href` for URL and `caption` for the display text (both string).
+          * List of links to add to the top nav. You can either use Markdown (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`) to avoid writing extra JS or assign this property an array where each item is an object with properties `href` for URL and `text` for the display text (both string).  To enable slot generation and routing, use the following URI scheme: `portal://tab-name`. This will create a slot for your tab content that will be displayed only when the appropriate tab link is clicked (works with hash-based routing too).
          */
-        "tabs": string | {
-            href: string;
-            caption: string;
-        }[];
+        "tabs": string | Tab[];
     }
     interface FoxyPluginWarning {
         /**
@@ -346,12 +344,9 @@ declare namespace LocalJSX {
          */
         "scope"?: string;
         /**
-          * List of links to add to the top nav. You can either use Markdown (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`) to avoid writing extra JS or assign this property an array where each item is an object with properties `href` for URL and `caption` for the display text (both string).
+          * List of links to add to the top nav. You can either use Markdown (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`) to avoid writing extra JS or assign this property an array where each item is an object with properties `href` for URL and `text` for the display text (both string).  To enable slot generation and routing, use the following URI scheme: `portal://tab-name`. This will create a slot for your tab content that will be displayed only when the appropriate tab link is clicked (works with hash-based routing too).
          */
-        "tabs"?: string | {
-            href: string;
-            caption: string;
-        }[];
+        "tabs"?: string | Tab[];
     }
     interface FoxyPluginWarning {
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -53,7 +53,7 @@ export namespace Components {
         /**
           * Resolves with a customer object (the state).
          */
-        "getRemoteState": () => Promise<import("/Users/dantothefuture/foxy-customer-portal/src/api/index").GetResponse<{
+        "getRemoteState": () => Promise<import("/Users/dantothefuture/Foxy/foxy-customer-portal/src/api/index").GetResponse<{
             zoom: Record<"default_billing_address" | "default_shipping_address" | "subscriptions" | "transactions" | "default_payment_method", true>;
             sso: true;
         }>>;
@@ -66,6 +66,13 @@ export namespace Components {
          */
         "locale": any;
         /**
+          * List of links to add to the top nav. You can either use Markdown (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`) to avoid writing extra JS or assign this property an array where each item is an object with properties `href` for URL and `caption` for the display text (both string).
+         */
+        "navLinks": string | {
+            href: string;
+            caption: string;
+        }[];
+        /**
           * Enables hash-based routing.
          */
         "router": boolean;
@@ -76,7 +83,7 @@ export namespace Components {
         /**
           * Updates the customer object, or the state.
          */
-        "setState": (value: Partial<import("/Users/dantothefuture/foxy-customer-portal/src/api/index").GetResponse<{
+        "setState": (value: Partial<import("/Users/dantothefuture/Foxy/foxy-customer-portal/src/api/index").GetResponse<{
             zoom: Record<"default_billing_address" | "default_shipping_address" | "subscriptions" | "transactions" | "default_payment_method", true>;
             sso: true;
         }>>) => Promise<void>;
@@ -314,6 +321,13 @@ declare namespace LocalJSX {
           * The language to display element content in.
          */
         "locale"?: any;
+        /**
+          * List of links to add to the top nav. You can either use Markdown (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`) to avoid writing extra JS or assign this property an array where each item is an object with properties `href` for URL and `caption` for the display text (both string).
+         */
+        "navLinks"?: string | {
+            href: string;
+            caption: string;
+        }[];
         /**
           * Fired when component becomes ready to be interacted with.
          */

--- a/src/components/customer-portal/customer-portal.e2e.ts
+++ b/src/components/customer-portal/customer-portal.e2e.ts
@@ -98,17 +98,18 @@ describe("HTMLFoxyCustomerPortalElement", () => {
 
     it("renders additional links with markdown syntax", async () => {
       await interceptAPIRequests(async ({ page, url, signIn }) => {
-        const links = "[Foo](http://example.com/0)[Bar](http://example.com/1)";
-        const content = `<${tag} endpoint="${url}" tabs="${links}"></${tag}>`;
+        const links = "[Foo](https://example.com/foo)[Bar](portal://bar)";
+        const content = `<${tag} endpoint="${url}" tabs="${links}" router></${tag}>`;
 
         await signIn();
         await page.setContent(content);
         await page.waitForEvent("ready");
 
-        const [foo, bar] = await page.findAll(`${tag} >>> vaadin-tab > a`);
+        const wrappers = await page.findAll(`${tag} >>> vaadin-tab > a`);
+        const [bar, foo] = wrappers.reverse();
 
-        expect(foo.getAttribute("href")).toEqual("http://example.com/0");
-        expect(bar.getAttribute("href")).toEqual("http://example.com/1");
+        expect(foo.getAttribute("href")).toEqual("https://example.com/foo");
+        expect(bar.getAttribute("href")).toEqual("#foxy-customer-portal--bar");
 
         expect(foo).toEqualText("Foo");
         expect(bar).toEqualText("Bar");
@@ -119,17 +120,17 @@ describe("HTMLFoxyCustomerPortalElement", () => {
       await interceptAPIRequests(async ({ page, url, signIn }) => {
         const tabs = [
           {
-            href: "https://foxy.io",
-            caption: "Home"
+            href: "https://example.com/foo",
+            text: "Foo"
           },
           {
-            href: "https://admin.foxycart.com",
-            caption: "Admin"
+            href: "portal://bar",
+            text: "Bar"
           }
         ];
 
         await signIn();
-        await page.setContent(`<${tag} endpoint="${url}"></${tag}>`);
+        await page.setContent(`<${tag} endpoint="${url}" router></${tag}>`);
         await page.waitForEvent("ready");
 
         const root = await page.find(tag);
@@ -137,11 +138,13 @@ describe("HTMLFoxyCustomerPortalElement", () => {
         await page.waitForChanges();
 
         const wrappers = await page.findAll(`${tag} >>> vaadin-tab > a`);
+        const [bar, foo] = wrappers.reverse();
 
-        for (let i = 0; i < wrappers.length - 1; ++i) {
-          expect(wrappers[i].getAttribute("href")).toEqual(tabs[i].href);
-          expect(wrappers[i]).toEqualText(tabs[i].caption);
-        }
+        expect(foo.getAttribute("href")).toEqual("https://example.com/foo");
+        expect(bar.getAttribute("href")).toEqual("#foxy-customer-portal--bar");
+
+        expect(foo).toEqualText("Foo");
+        expect(bar).toEqualText("Bar");
       });
     });
   });

--- a/src/components/customer-portal/customer-portal.e2e.ts
+++ b/src/components/customer-portal/customer-portal.e2e.ts
@@ -99,7 +99,7 @@ describe("HTMLFoxyCustomerPortalElement", () => {
     it("renders additional links with markdown syntax", async () => {
       await interceptAPIRequests(async ({ page, url, signIn }) => {
         const links = "[Foo](http://example.com/0)[Bar](http://example.com/1)";
-        const content = `<${tag} endpoint="${url}" nav-links="${links}"></${tag}>`;
+        const content = `<${tag} endpoint="${url}" tabs="${links}"></${tag}>`;
 
         await signIn();
         await page.setContent(content);
@@ -117,7 +117,7 @@ describe("HTMLFoxyCustomerPortalElement", () => {
 
     it("renders additional links when using js array", async () => {
       await interceptAPIRequests(async ({ page, url, signIn }) => {
-        const links = [
+        const tabs = [
           {
             href: "https://foxy.io",
             caption: "Home"
@@ -132,11 +132,15 @@ describe("HTMLFoxyCustomerPortalElement", () => {
         await page.setContent(`<${tag} endpoint="${url}"></${tag}>`);
         await page.waitForEvent("ready");
 
+        const root = await page.find(tag);
+        root.setProperty("tabs", tabs);
+        await page.waitForChanges();
+
         const wrappers = await page.findAll(`${tag} >>> vaadin-tab > a`);
 
         for (let i = 0; i < wrappers.length - 1; ++i) {
-          expect(wrappers[i].getAttribute("href")).toEqual(links[i].href);
-          expect(wrappers[i]).toEqualText(links[i].caption);
+          expect(wrappers[i].getAttribute("href")).toEqual(tabs[i].href);
+          expect(wrappers[i]).toEqualText(tabs[i].caption);
         }
       });
     });

--- a/src/components/customer-portal/customer-portal.spec.ts
+++ b/src/components/customer-portal/customer-portal.spec.ts
@@ -9,7 +9,7 @@ describe("HTMLFoxyCustomerPortalElement", () => {
   testStore("foxy-customer-portal");
   testI18N("foxy-customer-portal");
 
-  describe("navLinks property", () => {
+  describe("tabs property", () => {
     let page: SpecPage;
 
     beforeEach(async () => {
@@ -19,12 +19,12 @@ describe("HTMLFoxyCustomerPortalElement", () => {
       });
     });
 
-    it("has `navLinks` property", async () => {
-      expect(page.rootInstance).toHaveProperty("navLinks");
+    it("has `tabs` property", async () => {
+      expect(page.rootInstance).toHaveProperty("tabs");
     });
 
     it("uses an empty array as a default value", async () => {
-      expect(page.rootInstance.navLinks).toEqual([]);
+      expect(page.rootInstance.tabs).toEqual([]);
     });
   });
 });

--- a/src/components/customer-portal/customer-portal.spec.ts
+++ b/src/components/customer-portal/customer-portal.spec.ts
@@ -1,9 +1,30 @@
+import { SpecPage, newSpecPage } from "@stencil/core/testing";
 import { testLifecycle } from "../../assets/utils/testLifecycle";
 import { testStore } from "../../assets/utils/testStore";
 import { testI18N } from "../../assets/utils/testI18N";
+import { CustomerPortal } from "./customer-portal";
 
 describe("HTMLFoxyCustomerPortalElement", () => {
   testLifecycle("foxy-customer-portal");
   testStore("foxy-customer-portal");
   testI18N("foxy-customer-portal");
+
+  describe("navLinks property", () => {
+    let page: SpecPage;
+
+    beforeEach(async () => {
+      page = await newSpecPage({
+        components: [CustomerPortal],
+        html: "<foxy-customer-portal></foxy-customer-portal>"
+      });
+    });
+
+    it("has `navLinks` property", async () => {
+      expect(page.rootInstance).toHaveProperty("navLinks");
+    });
+
+    it("uses an empty array as a default value", async () => {
+      expect(page.rootInstance.navLinks).toEqual([]);
+    });
+  });
 });

--- a/src/components/customer-portal/customer-portal.tsx
+++ b/src/components/customer-portal/customer-portal.tsx
@@ -59,6 +59,14 @@ export class CustomerPortal
   /** Prefix for routes and other top-level identifiers. */
   @Prop() scope = "foxy-customer-portal";
 
+  /**
+   * List of links to add to the top nav. You can either use Markdown
+   * (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`)
+   * to avoid writing extra JS or assign this property an array where each item
+   * is an object with properties `href` for URL and `caption` for the display text (both string).
+   */
+  @Prop() navLinks: string | { href: string; caption: string }[] = [];
+
   @Watch("locale")
   onLocaleChange(newValue: string) {
     i18n.onLocaleChange.call(this, newValue);
@@ -159,7 +167,7 @@ export class CustomerPortal
           transactions: true
         }
       });
-    } catch (e) { }
+    } catch (e) {}
 
     return customer;
   }
@@ -217,6 +225,25 @@ export class CustomerPortal
     this.signout.emit();
   }
 
+  private get normalizedNavLinks() {
+    const results: Record<"href" | "caption", string>[] = [];
+
+    if (typeof this.navLinks === "string") {
+      const mdLink = /(?:__|[*#])|\[(.+?)]\((.+?)\)/gm;
+      let match: RegExpMatchArray | null = null;
+
+      while ((match = mdLink.exec(this.navLinks)) !== null) {
+        if (match.index === mdLink.lastIndex) mdLink.lastIndex++;
+        const [, caption, href] = match;
+        results.push({ href, caption });
+      }
+    } else {
+      results.push(...this.navLinks);
+    }
+
+    return results;
+  }
+
   render() {
     return (
       <article class="font-lumo">
@@ -242,6 +269,14 @@ export class CustomerPortal
                     loaded={Boolean(this.i18n)}
                     text={() => this.i18n[path]}
                   />
+                </vaadin-tab>
+              ))}
+
+              {this.normalizedNavLinks.map(({ href, caption }) => (
+                <vaadin-tab>
+                  <a href={href} tabIndex={-1} target="_blank" rel="noopener">
+                    {caption}
+                  </a>
                 </vaadin-tab>
               ))}
 

--- a/src/components/customer-portal/customer-portal.tsx
+++ b/src/components/customer-portal/customer-portal.tsx
@@ -65,7 +65,7 @@ export class CustomerPortal
    * to avoid writing extra JS or assign this property an array where each item
    * is an object with properties `href` for URL and `caption` for the display text (both string).
    */
-  @Prop() navLinks: string | { href: string; caption: string }[] = [];
+  @Prop() tabs: string | { href: string; caption: string }[] = [];
 
   @Watch("locale")
   onLocaleChange(newValue: string) {
@@ -225,20 +225,20 @@ export class CustomerPortal
     this.signout.emit();
   }
 
-  private get normalizedNavLinks() {
+  private get normalizedTabs() {
     const results: Record<"href" | "caption", string>[] = [];
 
-    if (typeof this.navLinks === "string") {
+    if (typeof this.tabs === "string") {
       const mdLink = /(?:__|[*#])|\[(.+?)]\((.+?)\)/gm;
       let match: RegExpMatchArray | null = null;
 
-      while ((match = mdLink.exec(this.navLinks)) !== null) {
+      while ((match = mdLink.exec(this.tabs)) !== null) {
         if (match.index === mdLink.lastIndex) mdLink.lastIndex++;
         const [, caption, href] = match;
         results.push({ href, caption });
       }
     } else {
-      results.push(...this.navLinks);
+      results.push(...this.tabs);
     }
 
     return results;

--- a/src/components/customer-portal/customer-portal.tsx
+++ b/src/components/customer-portal/customer-portal.tsx
@@ -23,10 +23,8 @@ import {
 
 import { FullGetResponse, get as getCustomer } from "../../api";
 import { Details } from "../Details";
-import { Messages } from "./types";
+import { Messages, Tab } from "./types";
 import { Skeleton } from "../Skeleton";
-
-const paths = ["activity", "account"] as const;
 
 @Component({
   tag: "foxy-customer-portal",
@@ -63,9 +61,13 @@ export class CustomerPortal
    * List of links to add to the top nav. You can either use Markdown
    * (`[Foo](https://example.com/foo) [Bar](https://example.com/bar)`)
    * to avoid writing extra JS or assign this property an array where each item
-   * is an object with properties `href` for URL and `caption` for the display text (both string).
+   * is an object with properties `href` for URL and `text` for the display text (both string).
+   *
+   * To enable slot generation and routing, use the following URI scheme: `portal://tab-name`.
+   * This will create a slot for your tab content that will be displayed only when the
+   * appropriate tab link is clicked (works with hash-based routing too).
    */
-  @Prop() tabs: string | { href: string; caption: string }[] = [];
+  @Prop() tabs: string | Tab[] = [];
 
   @Watch("locale")
   onLocaleChange(newValue: string) {
@@ -145,7 +147,10 @@ export class CustomerPortal
         this.tabIndex = 0;
       } else {
         const path = this.parseHash(location.hash);
-        const index = paths.findIndex(hash => hash === path);
+        const index = this.extendedTabs.findIndex(tab => {
+          return tab.isPortalLink && tab.path === path;
+        });
+
         if (index !== -1) this.tabIndex = index;
       }
     }
@@ -187,10 +192,11 @@ export class CustomerPortal
   private initRouter() {
     if (this.router) {
       const path = this.parseHash(location.hash);
+      const index = this.extendedTabs.findIndex(tab => {
+        return tab.isPortalLink && tab.path === path;
+      });
 
-      if (paths.findIndex(v => v === path) === -1) {
-        this.defaultPathAlias = location.hash;
-      }
+      if (index === -1) this.defaultPathAlias = location.hash;
     }
   }
 
@@ -207,14 +213,6 @@ export class CustomerPortal
     return hash;
   }
 
-  private goTo(path: typeof paths[number]) {
-    if (this.router) {
-      location.hash = this.createHash(path);
-    } else {
-      this.tabIndex = paths.indexOf(path);
-    }
-  }
-
   private async signOut() {
     resetAuthCookie();
     this.isSignedIn = false;
@@ -225,8 +223,21 @@ export class CustomerPortal
     this.signout.emit();
   }
 
-  private get normalizedTabs() {
-    const results: Record<"href" | "caption", string>[] = [];
+  private get defaultTabs() {
+    return [
+      {
+        href: "portal://activity",
+        text: this.i18n?.activity ?? ""
+      },
+      {
+        href: "portal://account",
+        text: this.i18n?.account ?? ""
+      }
+    ];
+  }
+
+  private get extendedTabs() {
+    const tabs = this.defaultTabs;
 
     if (typeof this.tabs === "string") {
       const mdLink = /(?:__|[*#])|\[(.+?)]\((.+?)\)/gm;
@@ -234,14 +245,21 @@ export class CustomerPortal
 
       while ((match = mdLink.exec(this.tabs)) !== null) {
         if (match.index === mdLink.lastIndex) mdLink.lastIndex++;
-        const [, caption, href] = match;
-        results.push({ href, caption });
+        const [, text, href] = match;
+        tabs.push({ href, text });
       }
     } else {
-      results.push(...this.tabs);
+      tabs.push(...this.tabs);
     }
 
-    return results;
+    return tabs.map(v => {
+      const isPortalLink = v.href.startsWith("portal://");
+      const text = v.text;
+      const path = isPortalLink ? v.href.replace("portal://", "") : v.href;
+      const href = this.router && isPortalLink ? this.createHash(path) : v.href;
+
+      return { isPortalLink, text, path, href };
+    });
   }
 
   render() {
@@ -260,22 +278,18 @@ export class CustomerPortal
 
           <nav role="navigation" class="w-full sm:w-auto">
             <vaadin-tabs selected={this.tabIndex} data-theme="minimal centered">
-              {paths.map(path => (
+              {this.extendedTabs.map((tab, index) => (
                 <vaadin-tab
-                  data-e2e={`lnk-${path}`}
-                  onClick={() => this.goTo(path)}
+                  data-e2e={`lnk-${tab.path}`}
+                  onClick={() => !this.router && (this.tabIndex = index)}
                 >
-                  <Skeleton
-                    loaded={Boolean(this.i18n)}
-                    text={() => this.i18n[path]}
-                  />
-                </vaadin-tab>
-              ))}
-
-              {this.normalizedNavLinks.map(({ href, caption }) => (
-                <vaadin-tab>
-                  <a href={href} tabIndex={-1} target="_blank" rel="noopener">
-                    {caption}
+                  <a
+                    tabIndex={-1}
+                    target={!tab.isPortalLink && "_blank"}
+                    href={this.router && tab.href}
+                    rel="nofollow noopener noreferrer"
+                  >
+                    {tab.text}
                   </a>
                 </vaadin-tab>
               ))}
@@ -301,100 +315,112 @@ export class CustomerPortal
           </slot>
         </section>
 
-        <section hidden={!this.isSignedIn || this.tabIndex !== 0}>
-          <div class="mb-s sm:mb-m">
-            <slot name="subscriptions-container">
-              <Details
-                open={this.areSubscriptionsOpen}
-                summary={() => this.i18n.subscriptions}
-                loaded={this.i18n && this.state.id !== -1}
-                onToggle={v => (this.areSubscriptionsOpen = v)}
-              >
-                <slot name="subscriptions">
-                  <foxy-subscriptions
-                    locale={this.locale}
-                    endpoint={this.endpoint}
-                  />
-                </slot>
-              </Details>
-            </slot>
-          </div>
+        {this.extendedTabs.map((tab, index) => {
+          if (!tab.isPortalLink) return;
 
-          <div class="mb-s sm:mb-m">
-            <slot name="transactions-container">
-              <Details
-                open={this.areTransactionsOpen}
-                summary={() => this.i18n.transactions}
-                loaded={this.i18n && this.state.id !== -1}
-                onToggle={v => (this.areTransactionsOpen = v)}
-              >
-                <slot name="transactions">
-                  <foxy-transactions
-                    locale={this.locale}
-                    endpoint={this.endpoint}
-                  />
-                </slot>
-              </Details>
-            </slot>
-          </div>
+          return (
+            <section hidden={!this.isSignedIn || this.tabIndex !== index}>
+              <slot name={tab.path}>
+                {index === 0 && [
+                  <div class="mb-s sm:mb-m">
+                    <slot name="subscriptions-container">
+                      <Details
+                        open={this.areSubscriptionsOpen}
+                        summary={() => this.i18n.subscriptions}
+                        loaded={this.i18n && this.state.id !== -1}
+                        onToggle={v => (this.areSubscriptionsOpen = v)}
+                      >
+                        <slot name="subscriptions">
+                          <foxy-subscriptions
+                            locale={this.locale}
+                            endpoint={this.endpoint}
+                          />
+                        </slot>
+                      </Details>
+                    </slot>
+                  </div>,
 
-          <div class="mb-s sm:mb-m">
-            <slot name="downloadables-container">
-              {/* <Details
-              open={this.areDownloadsOpen}
-              summary={() => this.i18n.downloads}
-              loaded={this.i18n && this.state.id !== -1}
-              onToggle={v => (this.areDownloadsOpen = v)}
-            >
-              <slot name="downloadables">
-                <div class="p-m text-body">
-                  <Skeleton
-                    loaded={Boolean(this.i18n)}
-                    text={() => this.i18n.comingSoon}
-                  />
-                </div>
+                  <div class="mb-s sm:mb-m">
+                    <slot name="transactions-container">
+                      <Details
+                        open={this.areTransactionsOpen}
+                        summary={() => this.i18n.transactions}
+                        loaded={this.i18n && this.state.id !== -1}
+                        onToggle={v => (this.areTransactionsOpen = v)}
+                      >
+                        <slot name="transactions">
+                          <foxy-transactions
+                            locale={this.locale}
+                            endpoint={this.endpoint}
+                          />
+                        </slot>
+                      </Details>
+                    </slot>
+                  </div>,
+
+                  <div class="mb-s sm:mb-m">
+                    <slot name="downloadables-container">
+                      {/* <Details
+                        open={this.areDownloadsOpen}
+                        summary={() => this.i18n.downloads}
+                        loaded={this.i18n && this.state.id !== -1}
+                        onToggle={v => (this.areDownloadsOpen = v)}
+                      >
+                        <slot name="downloadables">
+                          <div class="p-m text-body">
+                            <Skeleton
+                              loaded={Boolean(this.i18n)}
+                              text={() => this.i18n.comingSoon}
+                            />
+                          </div>
+                        </slot>
+                      </Details> */}
+                    </slot>
+                  </div>
+                ]}
+
+                {index === 1 && (
+                  <div class="flex flex-wrap sm:-m-s">
+                    <div class="w-full pb-s sm:w-1/2 sm:p-s">
+                      <div class="bg-base sm:rounded-m sm:shadow-xs">
+                        <slot name="billing-address">
+                          <foxy-address
+                            type="default_billing_address"
+                            endpoint={this.endpoint}
+                            locale={this.locale}
+                          />
+                        </slot>
+                      </div>
+                    </div>
+
+                    <div class="w-full pb-s sm:w-1/2 sm:p-s">
+                      <div class="bg-base sm:rounded-m sm:shadow-xs">
+                        <slot name="shipping-address">
+                          <foxy-address
+                            type="default_shipping_address"
+                            endpoint={this.endpoint}
+                            locale={this.locale}
+                          />
+                        </slot>
+                      </div>
+                    </div>
+
+                    <div class="w-full sm:w-1/2 sm:p-s">
+                      <div class="bg-base sm:rounded-m sm:shadow-xs">
+                        <slot name="profile">
+                          <foxy-profile
+                            endpoint={this.endpoint}
+                            locale={this.locale}
+                          />
+                        </slot>
+                      </div>
+                    </div>
+                  </div>
+                )}
               </slot>
-            </Details> */}
-            </slot>
-          </div>
-        </section>
-
-        <section
-          hidden={!this.isSignedIn || this.tabIndex !== 1}
-          class="flex flex-wrap sm:-m-s"
-        >
-          <div class="w-full pb-s sm:w-1/2 sm:p-s">
-            <div class="bg-base sm:rounded-m sm:shadow-xs">
-              <slot name="billing-address">
-                <foxy-address
-                  type="default_billing_address"
-                  endpoint={this.endpoint}
-                  locale={this.locale}
-                />
-              </slot>
-            </div>
-          </div>
-
-          <div class="w-full pb-s sm:w-1/2 sm:p-s">
-            <div class="bg-base sm:rounded-m sm:shadow-xs">
-              <slot name="shipping-address">
-                <foxy-address
-                  type="default_shipping_address"
-                  endpoint={this.endpoint}
-                  locale={this.locale}
-                />
-              </slot>
-            </div>
-          </div>
-
-          <div class="w-full sm:w-1/2 sm:p-s">
-            <div class="bg-base sm:rounded-m sm:shadow-xs">
-              <slot name="profile">
-                <foxy-profile endpoint={this.endpoint} locale={this.locale} />
-              </slot>
-            </div>
-          </div>
-        </section>
+            </section>
+          );
+        })}
       </article>
     );
   }

--- a/src/components/customer-portal/types.ts
+++ b/src/components/customer-portal/types.ts
@@ -4,6 +4,11 @@ export type StateConsumer =
   | HTMLFoxySubscriptionsElement
   | HTMLFoxyTransactionsElement;
 
+export interface Tab {
+  href: string;
+  text: string;
+}
+
 export interface Messages {
   /** Salutation text. */
   greeting: (name: string) => string;

--- a/src/demos/nav-links.html
+++ b/src/demos/nav-links.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en" class="bg-gray-100">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+
+    <title>Adding top nav links</title>
+
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css"
+    />
+
+    <script type="module" src="/build/foxy.esm.js"></script>
+  </head>
+
+  <body class="container mx-auto py-8 sm:px-8">
+    <h1 class="text-2xl mx-4 mb-12">Adding top nav links</h1>
+
+    <h2 class="text-lg text-gray-500 border-b py-2 mx-4 mb-6">
+      Example 1: using Markdown
+    </h2>
+
+    <foxy-customer-portal
+      nav-links="[Home](https://foxy.io) [Admin](https://admin.foxycart.com)"
+      endpoint="http://localhost:5000"
+    ></foxy-customer-portal>
+
+    <h2 class="text-lg text-gray-500 border-b py-2 mx-4 mt-12 mb-6">
+      Example 2: using JS Array
+    </h2>
+
+    <foxy-customer-portal
+      id="demo2"
+      endpoint="http://localhost:5000"
+    ></foxy-customer-portal>
+
+    <script>
+      document.getElementById("demo2").addEventListener("ready", e => {
+        e.target.navLinks = [
+          {
+            href: "https://foxy.io",
+            caption: "Home"
+          },
+          {
+            href: "https://admin.foxycart.com",
+            caption: "Admin"
+          }
+        ];
+      });
+    </script>
+  </body>
+</html>

--- a/src/demos/tabs.html
+++ b/src/demos/tabs.html
@@ -15,6 +15,12 @@
     />
 
     <script type="module" src="/build/foxy.esm.js"></script>
+
+    <style>
+      .bg-blue-500 {
+        background-color: var(--foxy-primary-color);
+      }
+    </style>
   </head>
 
   <body class="container mx-auto py-8 sm:px-8">
@@ -27,27 +33,37 @@
     <foxy-customer-portal
       tabs="[Home](https://foxy.io) [About](portal://about)"
       endpoint="http://localhost:5000"
-    ></foxy-customer-portal>
+      router
+    >
+      <div slot="about" class="text-white bg-blue-500 rounded p-4 m-4">
+        This content will be displayed only when the About link is clicked. If
+        the hash-based routing option is on, this content will also be displayed
+        when the URL hash matches "about" (e.g. https://example.com#about).
+      </div>
+    </foxy-customer-portal>
 
     <h2 class="text-lg text-gray-500 border-b py-2 mx-4 mt-12 mb-6">
       Example 2: using JS Array
     </h2>
 
-    <foxy-customer-portal
-      id="demo2"
-      endpoint="http://localhost:5000"
-    ></foxy-customer-portal>
+    <foxy-customer-portal id="demo2" endpoint="http://localhost:5000" router>
+      <div slot="about" class="text-white bg-blue-500 rounded p-4 m-4">
+        This content will be displayed only when the About link is clicked. If
+        the hash-based routing option is on, this content will also be displayed
+        when the URL hash matches "about" (e.g. https://example.com#about).
+      </div>
+    </foxy-customer-portal>
 
     <script>
       document.getElementById("demo2").addEventListener("ready", e => {
         e.target.tabs = [
           {
             href: "https://foxy.io",
-            caption: "Home"
+            text: "Home"
           },
           {
-            href: "https://admin.foxycart.com",
-            caption: "Admin"
+            href: "portal://about",
+            text: "About"
           }
         ];
       });

--- a/src/demos/tabs.html
+++ b/src/demos/tabs.html
@@ -25,7 +25,7 @@
     </h2>
 
     <foxy-customer-portal
-      nav-links="[Home](https://foxy.io) [Admin](https://admin.foxycart.com)"
+      tabs="[Home](https://foxy.io) [About](portal://about)"
       endpoint="http://localhost:5000"
     ></foxy-customer-portal>
 
@@ -40,7 +40,7 @@
 
     <script>
       document.getElementById("demo2").addEventListener("ready", e => {
-        e.target.navLinks = [
+        e.target.tabs = [
           {
             href: "https://foxy.io",
             caption: "Home"

--- a/src/index.html
+++ b/src/index.html
@@ -37,7 +37,7 @@
         <a href="demos/subscription.html">Standalone subscription</a>
       </li>
       <li>
-        <a href="demos/nav-links.html">Adding top nav links</a>
+        <a href="demos/tabs.html">Adding top nav links</a>
       </li>
     </ul>
   </body>

--- a/src/index.html
+++ b/src/index.html
@@ -36,6 +36,9 @@
       <li>
         <a href="demos/subscription.html">Standalone subscription</a>
       </li>
+      <li>
+        <a href="demos/nav-links.html">Adding top nav links</a>
+      </li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
This PR adds a new property called `tabs` to the `foxy-customer-portal` element, allowing host environments to extend the default set of links displayed in the top navigation bar. It also makes it possible to create new views within the portal that work with the existing routing functionality and the `tabs` settings. Examples:

1. Add tabs with Markdown:
```html
<foxy-customer-portal tabs="[Home](foxy.io) [Admin](admin.foxycart.com)"></foxy-customer-portal>
```

2. Add tabs with JS:

```html
<foxy-customer-portal id="demo"></foxy-customer-portal>
<script>
  document.getElementById("demo").addEventListener("ready", e => {
    e.target.tabs = [{
      href: "https://foxy.io",
      text: "Home"
    }];
  });
</script>
```

3. Add portal page and link it to a tab:

```html
<foxy-customer-portal tabs="[About](portal://about)">
  <div slot="about">About page content</div>
</foxy-customer-portal>
```

The same is achievable with JS. The trick is to use a special URI format with the `portal://` "protocol" prefix – this is how the component knows that this is an internal page and not an external resource. It works with the hash-based routing as well:

```html
<foxy-customer-portal tabs="[About](portal://about)" router>
  <div slot="about">
    About page content will be available at #foxy-customer-portal--about
    by default (you can still change the scope prefix via the respective property)
  </div>
</foxy-customer-portal>
```