### PR TITLE
Add text to EditableCard save button

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,27 @@ If you aren't doing subscriptions or downloadables, you can override those eleme
 ```
 
 Overriding language strings is easy, but **note that this approach will change when this portal comes out of beta** (at which point the language strings will be configurable from the Foxy admin, like all other language strings):
+
 ```html
 <script>
+  // For the parent component
   document.querySelector('foxy-customer-portal').locale = {
+    "en": {
+      "receipt": "Purchase Order",
+      "receiptLink": "Purchase Order"
+    }
+  };
+  // For child components
+  const foxyPortal = document.querySelector("foxy-customer-portal");
+  foxyPortal.shadowRoot.querySelectorAll('foxy-address').forEach(e => {
+    e.locale = {
       "en": {
-        "receipt": "Purchase Order",
-        "receiptLink": "Purchase Order"
+        "postal_code": "ZIP Code",
+        "save": () => "Save Changes" // Note that some language strings must be functions
       }
-    };
+    }
+  })
+
 </script>
 ```
 

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -2,6 +2,7 @@ import { FunctionalComponent, h } from "@stencil/core";
 import { Skeleton } from "./Skeleton";
 
 interface Props {
+  i18n: { save: string };
   editable: boolean;
   loaded: boolean;
   saving: boolean;
@@ -47,7 +48,8 @@ export const EditableCard: FunctionalComponent<Props> = (props, children) => (
             disabled={!props.loaded}
             onClick={props.onSave}
           >
-            <iron-icon class="text-xxs" icon="icons:check" />
+            <iron-icon slot="prefix" icon="icons:check" />
+            {props.i18n.save}
           </vaadin-button>
         </div>
       )}

--- a/src/components/address/address.tsx
+++ b/src/components/address/address.tsx
@@ -270,6 +270,7 @@ export class Address
   render() {
     return (
       <EditableCard
+        i18n={{ save: this.i18n?.save(this.type) ?? "" }}
         saving={this.isSaving}
         editable={this.isEditable}
         summary={() => this.i18n.title(this.type)}

--- a/src/components/address/i18n/en.ts
+++ b/src/components/address/i18n/en.ts
@@ -15,7 +15,10 @@ export const messages: Messages = {
       postal_code: "Postal code",
       country: "Country"
     }[key]),
-  save: "Save",
+  save: type =>
+    `Save ${
+      type === "default_shipping_address" ? "shipping" : "billing"
+    } address`,
   close: "Close",
   error:
     "An unknown error has occurred. Please try again later or contact us for help.",

--- a/src/components/address/i18n/en.ts
+++ b/src/components/address/i18n/en.ts
@@ -4,15 +4,15 @@ export const messages: Messages = {
   title: type => (type === "default_shipping_address" ? "Shipping" : "Billing"),
   label: key =>
     ({
-      first_name: "First name",
-      last_name: "Last name",
+      first_name: "First Name",
+      last_name: "Last Name",
       company: "Company",
       phone: "Phone",
       address1: "Address Line 1",
       address2: "Address Line 2",
       city: "City",
       region: "Region",
-      postal_code: "Postal code",
+      postal_code: "Postal Code",
       country: "Country"
     }[key]),
   save: type =>

--- a/src/components/address/i18n/fr.ts
+++ b/src/components/address/i18n/fr.ts
@@ -16,7 +16,10 @@ export const messages: Messages = {
       postal_code: "Code Postal",
       country: "Pays"
     }[key]),
-  save: "Sauvegarder",
+  save: type =>
+    `Sauvegarder l'adresse de ${
+      type === "default_shipping_address" ? "livraison" : "facturation"
+    }`,
   close: "Fermer",
   error:
     "Une erreur inconnue s'est produite. Veuillez réessayer plus tard ou contactez-nous pour obtenir de l'aide",

--- a/src/components/address/i18n/ru.ts
+++ b/src/components/address/i18n/ru.ts
@@ -16,7 +16,10 @@ export const messages: Messages = {
       postal_code: "Индекс",
       country: "Страна"
     }[key]),
-  save: "Сохранить",
+  save: type =>
+    `Сохранить ${
+      type === "default_shipping_address" ? "адрес доставки" : "платежный адрес"
+    }`,
   close: "Закрыть",
   error:
     "Кажется, у нас что-то сломалось. Пожалуйста, попробуйте еще раз или напишите нам.",

--- a/src/components/address/types.ts
+++ b/src/components/address/types.ts
@@ -12,7 +12,7 @@ export interface Messages {
   label: (field: keyof Address) => string;
 
   /** "Save" button caption. */
-  save: string;
+  save: (type: AddressType) => string;
 
   /** Error overlay action text. */
   close: string;

--- a/src/components/profile/i18n/en.ts
+++ b/src/components/profile/i18n/en.ts
@@ -1,6 +1,7 @@
 import { Messages } from "../types";
 
 export const messages: Messages = {
+  save: "Save profile",
   title: "Login",
   email: "Email",
   password: "Password",

--- a/src/components/profile/i18n/fr.ts
+++ b/src/components/profile/i18n/fr.ts
@@ -1,6 +1,7 @@
 import { Messages } from "../types";
 
 export const messages: Messages = {
+  save: "Sauvegarder le profil",
   title: "Connexion",
   email: "Courriel",
   password: "Mot de passe",

--- a/src/components/profile/i18n/ru.ts
+++ b/src/components/profile/i18n/ru.ts
@@ -1,6 +1,7 @@
 import { Messages } from "../types";
 
 export const messages: Messages = {
+  save: "Сохранить профиль",
   title: "Вход",
   email: "Email",
   password: "Пароль",

--- a/src/components/profile/profile.tsx
+++ b/src/components/profile/profile.tsx
@@ -194,6 +194,7 @@ export class Profile
   render() {
     return (
       <EditableCard
+        i18n={this.i18n}
         summary={() => this.i18n.title}
         loaded={this.isContentAvailable}
         saving={this.isSaving}

--- a/src/components/profile/types.ts
+++ b/src/components/profile/types.ts
@@ -1,4 +1,7 @@
 export interface Messages {
+  /** Save button text. */
+  save: string;
+
   /** Component title text. */
   title: string;
 


### PR DESCRIPTION
This PR fixes the following issue submitted by @brettflorio:

> We've received feedback that the checkmark to save an address update isn't super clear, and we don't disagree. Related to this line in EditableCard.tsx, let's add some text to the right of the button.
> 
> Default to "Save" in English, and comparable for other languages. Ideally, this text should be overridable per instance, so we could have "Save Billing Address" and "Save Shipping Address" on the same page.

Closes: #21 