### PR TITLE
Address text display customizaton issues

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -21,7 +21,7 @@ interface Props<T> {
 
 function createDataTable<T>(): FunctionalComponent<Props<T>> {
   return (props, children = []) => (
-    <div class="relative flex flex-wrap justify-between font-lumo whitespace-no-wrap">
+    <div class="relative flex flex-wrap justify-between font-lumo whitespace-no-wrap leading-s">
       <div class="w-full overflow-auto">
         <table class="block w-full text-left text-body border-collapse sm:table">
           <thead class="hidden sm:table-header-group">

--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -24,7 +24,7 @@ export const Details: FunctionalComponent<Props> = (props, children) => (
       }}
     >
       <div class="text-xl select-none flex justify-between items-center px-m h-xl">
-        <div class="flex-1 truncate mr-m">
+        <div class="flex-1 mr-m">
           <Skeleton loaded={props.loaded} text={props.summary} />
         </div>
         <iron-icon

--- a/src/components/EditableCard.tsx
+++ b/src/components/EditableCard.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export const EditableCard: FunctionalComponent<Props> = (props, children) => (
-  <div class="overflow-hidden font-lumo relative">
+  <div class="overflow-hidden font-lumo relative leading-s">
     <div
       class={{
         "text-body text-xl select-none flex justify-between items-center px-m h-xl": true,

--- a/src/components/ErrorOverlay.tsx
+++ b/src/components/ErrorOverlay.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export const ErrorOverlay: FunctionalComponent<Props> = props => (
   <div
-    class="absolute inset-0 z-10 flex flex-col items-center justify-center bg-base"
+    class="absolute inset-0 z-10 flex flex-col items-center justify-center bg-base leading-s"
     role="alert"
     aria-live="assertive"
     data-e2e="error"

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -29,6 +29,7 @@ export const Notification: FunctionalComponent<Props> = props => (
       }
 
       span.textContent = props.text;
+      span.style.lineHeight = "var(--foxy-line-height-s)";
     }}
   />
 );

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 export const Skeleton: FunctionalComponent<Props> = props => (
-  <div class="relative" aria-busy={!props.loaded} role="alert">
+  <div class="relative leading-s" aria-busy={!props.loaded} role="alert">
     {props.loaded
       ? props.text()
       : [

--- a/src/components/address/address.tsx
+++ b/src/components/address/address.tsx
@@ -356,28 +356,28 @@ export class Address
             />
           </h3>
 
-          <div class="truncate" data-e2e="lbl-name">
+          <div data-e2e="lbl-name">
             <Skeleton
               loaded={this.isContentAvailable}
               text={() => this.i18n.getFullName(this.address)}
             />
           </div>
 
-          <div class="mb-m truncate" data-e2e="lbl-address">
+          <div class="mb-m" data-e2e="lbl-address">
             <Skeleton
               loaded={this.isContentAvailable}
               text={() => this.i18n.getAddress(this.address)}
             />
           </div>
 
-          <h3 class="font-bold text-tertiary truncate">
+          <h3 class="font-bold text-tertiary">
             <Skeleton
               loaded={this.isContentAvailable}
               text={() => this.i18n.phone}
             />
           </h3>
 
-          <div class="truncate" data-e2e="lbl-phone">
+          <div data-e2e="lbl-phone">
             <Skeleton
               loaded={this.isContentAvailable}
               text={() => this.address.phone}

--- a/src/components/customer-portal/customer-portal.tsx
+++ b/src/components/customer-portal/customer-portal.tsx
@@ -272,7 +272,7 @@ export class CustomerPortal
           hidden={!this.isSignedIn}
           class="pt-xl pb-s flex flex-wrap sm:py-l sm:flex-no-wrap"
         >
-          <h1 class="text-header text-xxl px-m text-center flex-1 sm:text-left">
+          <h1 class="text-header text-xxl px-m text-center flex-1 sm:flex sm:items-center sm:text-left">
             <Skeleton
               loaded={this.i18n && this.state.id !== -1}
               text={() => this.i18n.greeting(this.state.first_name)}

--- a/src/components/customer-portal/customer-portal.tsx
+++ b/src/components/customer-portal/customer-portal.tsx
@@ -267,7 +267,7 @@ export class CustomerPortal
 
   render() {
     return (
-      <article class="font-lumo">
+      <article class="font-lumo leading-s">
         <header
           hidden={!this.isSignedIn}
           class="pt-xl pb-s flex flex-wrap sm:py-l sm:flex-no-wrap"

--- a/src/components/customer-portal/customer-portal.tsx
+++ b/src/components/customer-portal/customer-portal.tsx
@@ -26,6 +26,12 @@ import { Details } from "../Details";
 import { Messages, Tab } from "./types";
 import { Skeleton } from "../Skeleton";
 
+/**
+ * @part transaction-id - Targets each cell in the ID column of the nested `foxy-transactions` element.
+ * @part transaction-date - Targets each cell in the Date column of the nested `foxy-transactions` element.
+ * @part transaction-total - Targets each cell in the Total column of the nested `foxy-transactions` element.
+ * @part transaction-receipt - Targets each cell in the Recept column of the nested `foxy-transactions` element.
+ */
 @Component({
   tag: "foxy-customer-portal",
   styleUrl: "../../tailwind.css",
@@ -359,6 +365,7 @@ export class CustomerPortal
                           <foxy-transactions
                             locale={this.locale}
                             endpoint={this.endpoint}
+                            exportparts="id:transaction-id,date:transaction-date,total:transaction-total,receipt:transaction-receipt"
                           />
                         </slot>
                       </Details>

--- a/src/components/customer-portal/customer-portal.tsx
+++ b/src/components/customer-portal/customer-portal.tsx
@@ -272,7 +272,7 @@ export class CustomerPortal
           hidden={!this.isSignedIn}
           class="pt-xl pb-s flex flex-wrap sm:py-l sm:flex-no-wrap"
         >
-          <h1 class="truncate text-header text-xxl px-m text-center flex-1 sm:text-left">
+          <h1 class="text-header text-xxl px-m text-center flex-1 sm:text-left">
             <Skeleton
               loaded={this.i18n && this.state.id !== -1}
               text={() => this.i18n.greeting(this.state.first_name)}

--- a/src/components/customer-portal/readme.md
+++ b/src/components/customer-portal/readme.md
@@ -59,6 +59,16 @@ Type: `Promise<void>`
 
 
 
+## Shadow Parts
+
+| Part                    | Description                                                                       |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| `"transaction-date"`    | Targets each cell in the Date column of the nested `foxy-transactions` element.   |
+| `"transaction-id"`      | Targets each cell in the ID column of the nested `foxy-transactions` element.     |
+| `"transaction-receipt"` | Targets each cell in the Recept column of the nested `foxy-transactions` element. |
+| `"transaction-total"`   | Targets each cell in the Total column of the nested `foxy-transactions` element.  |
+
+
 ## Dependencies
 
 ### Depends on

--- a/src/components/plugin-warning/plugin-warning.tsx
+++ b/src/components/plugin-warning/plugin-warning.tsx
@@ -79,7 +79,9 @@ export class PluginWarning
           action.setAttribute("theme", "small");
           action.addEventListener("click", () => this.close());
 
+          layout.style.lineHeight = "var(--foxy-line-height-s)";
           layout.append(message, action);
+
           root.append(layout);
         }}
       />

--- a/src/components/profile/profile.tsx
+++ b/src/components/profile/profile.tsx
@@ -268,28 +268,28 @@ export class Profile
         </form>
 
         <div hidden={this.isEditable} class="text-body pb-m px-m">
-          <h3 class="font-bold text-tertiary truncate">
+          <h3 class="font-bold text-tertiary">
             <Skeleton
               loaded={this.isContentAvailable}
               text={() => this.i18n.email}
             />
           </h3>
 
-          <div class="truncate mb-m" data-e2e="lbl-email">
+          <div class="mb-m" data-e2e="lbl-email">
             <Skeleton
               loaded={this.isContentAvailable}
               text={() => this.state.email}
             />
           </div>
 
-          <h3 class="font-bold text-tertiary truncate">
+          <h3 class="font-bold text-tertiary">
             <Skeleton
               loaded={this.isContentAvailable}
               text={() => this.i18n.password}
             />
           </h3>
 
-          <div class="truncate">
+          <div>
             <Skeleton
               loaded={this.isContentAvailable}
               text={() => "∗∗∗∗∗∗∗∗∗∗"}

--- a/src/components/sign-in/sign-in.tsx
+++ b/src/components/sign-in/sign-in.tsx
@@ -143,7 +143,7 @@ export class SignIn implements vaadin.Mixin, i18n.Mixin<typeof i18nProvider> {
     return (
       <form
         ref={el => (this.formElement = el)}
-        class="p-m flex flex-col items-center justify-center font-lumo"
+        class="p-m flex flex-col items-center justify-center font-lumo leading-s"
         onSubmit={e => this.handleSubmit(e)}
       >
         <slot />

--- a/src/components/subscription/partials/Summary.tsx
+++ b/src/components/subscription/partials/Summary.tsx
@@ -71,7 +71,7 @@ export const Summary: FunctionalComponent<Props> = ({
 
         <div class="px-s flex-1 min-w-0">
           <div class="min-w-0">
-            <p class="leading-xs text-body text-m truncate font-medium origin-top-left md:text-l">
+            <p class="leading-xs text-body text-m font-medium origin-top-left md:text-l">
               <Skeleton
                 loaded={Boolean(subscription)}
                 text={() => getTitle(i18n, subscription)}
@@ -80,7 +80,7 @@ export const Summary: FunctionalComponent<Props> = ({
 
             <p
               class={{
-                "leading-xs text-xs truncate md:text-m": true,
+                "leading-xs text-xs md:text-m": true,
                 "text-tertiary": open || status === "cancelled",
                 "text-success": status === "active",
                 "text-error": status === "failed"

--- a/src/components/subscription/subscription.tsx
+++ b/src/components/subscription/subscription.tsx
@@ -277,7 +277,7 @@ export class Subscription implements Mixins {
   render() {
     return (
       <details
-        class="relative bg-base font-lumo overflow-hidden"
+        class="relative bg-base font-lumo overflow-hidden leading-s"
         onToggle={() => (this.open = !this.open)}
       >
         {this.error && (

--- a/src/components/subscriptions/subscriptions.tsx
+++ b/src/components/subscriptions/subscriptions.tsx
@@ -208,7 +208,7 @@ export class Subscriptions
 
   render() {
     return (
-      <div class="flex flex-wrap justify-between">
+      <div class="flex flex-wrap justify-between leading-s font-lumo">
         {this.displayedSubscriptions.map((value, index) => [
           <div
             class={{

--- a/src/components/transactions/readme.md
+++ b/src/components/transactions/readme.md
@@ -57,6 +57,16 @@ Type: `Promise<void>`
 
 
 
+## Shadow Parts
+
+| Part        | Description                             |
+| ----------- | --------------------------------------- |
+| `"date"`    | Targets each cell in the Date column.   |
+| `"id"`      | Targets each cell in the ID column.     |
+| `"receipt"` | Targets each cell in the Recept column. |
+| `"total"`   | Targets each cell in the Total column.  |
+
+
 ## Dependencies
 
 ### Used by

--- a/src/components/transactions/transactions.tsx
+++ b/src/components/transactions/transactions.tsx
@@ -32,6 +32,12 @@ type StoreMixin = store.Mixin<
   }>
 >;
 
+/**
+ * @part id - Targets each cell in the ID column.
+ * @part date - Targets each cell in the Date column.
+ * @part total - Targets each cell in the Total column.
+ * @part receipt - Targets each cell in the Recept column.
+ */
 @Component({
   tag: "foxy-transactions",
   styleUrl: "../../tailwind.css",
@@ -222,7 +228,7 @@ export class Transactions
         ]}
         cells={[
           item => (
-            <div class="flex items-center font-tnum text-s sm:text-m">
+            <div class="flex items-center font-tnum text-s sm:text-m" part="id">
               <div class="text-contrast-50 mr-s sm:hidden">
                 <Skeleton
                   loaded={Boolean(this.i18n)}
@@ -233,7 +239,10 @@ export class Transactions
             </div>
           ),
           item => (
-            <div class="flex items-center font-tnum text-s sm:text-m">
+            <div
+              class="flex items-center font-tnum text-s sm:text-m"
+              part="date"
+            >
               <div class="text-contrast-50 mr-s sm:hidden">
                 <Skeleton
                   loaded={Boolean(this.i18n)}
@@ -248,7 +257,10 @@ export class Transactions
             </div>
           ),
           item => (
-            <div class="font-tnum select-none text-xxl font-thin sm:font-normal sm:text-m">
+            <div
+              class="font-tnum select-none text-xxl font-thin sm:font-normal sm:text-m"
+              part="total"
+            >
               {item.total_order.toLocaleString(this.locale, {
                 style: "currency",
                 currency: item.currency_code
@@ -256,7 +268,7 @@ export class Transactions
             </div>
           ),
           item => (
-            <div class="-mx-s">
+            <div class="-mx-s" part="receipt">
               <LinkButton
                 target="_blank"
                 href={item._links["fx:receipt"].href}


### PR DESCRIPTION
This PR fixes a couple of issues related to text display and adds new customization capabilities for the transactions table.

## Bugfixes

- use `--foxy-line-height-s` (or `.leading-s` internally) as default line height;
- avoid truncating text where possible;
- align top header with navigation in `foxy-customer-portal`.

## Features

- add `id`, `date`, `total` and `receipt` [shadow parts](https://www.w3.org/TR/css-shadow-parts-1/) targeting cells in respective table columns to `foxy-transactions`;
- forward the above shadow parts in `foxy-customer-portal` (named `transaction-id`, `transaction-date`, `transaction-total` and `transaction-receipt` respectively).