### PR TITLE
feat: add sub modify link ui

### DIFF
--- a/src/assets/schema/Subscription.json
+++ b/src/assets/schema/Subscription.json
@@ -22,6 +22,9 @@
               "properties": {
                 "fx:sub_token_url": {
                   "$ref": "./Link.json"
+                },
+                "fx:sub_modification_url": {
+                  "$ref": "./Link.json"
                 }
               }
             }

--- a/src/assets/types/Subscription.ts
+++ b/src/assets/types/Subscription.ts
@@ -125,6 +125,23 @@ export type Subscription = {
        */
       type?: string;
     };
+    /**
+     * A named resource link of a particular type.
+     */
+    "fx:sub_modification_url"?: {
+      /**
+       * A few words describing where this link points.
+       */
+      title: string;
+      /**
+       * An absolute URL of the resource.
+       */
+      href: string;
+      /**
+       * Link type (optional, value depending on the context).
+       */
+      type?: string;
+    };
   };
   /**
    * Embedded content.

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -5,7 +5,7 @@ interface Props {
   href?: string;
   text?: string;
   size?: "m" | "s";
-  color?: "secondary" | "body";
+  color?: "secondary" | "primary" | "body";
 }
 
 export const Link: FunctionalComponent<Props> = props => (
@@ -18,6 +18,7 @@ export const Link: FunctionalComponent<Props> = props => (
       "text-s": props.size === "s",
       "text-m": !Boolean(props.size) || props.size === "m",
       "text-body": !Boolean(props.color) || props.color === "body",
+      "text-primary": props.color === "primary",
       "text-secondary": props.color === "secondary",
       "px-xs -mx-xs inline-block rounded-m leading-s font-medium hover:no-underline focus:outline-none": true,
       "transition duration-150 hover:text-primary focus:shadow-outline": Boolean(

--- a/src/components/subscription/i18n/cy.ts
+++ b/src/components/subscription/i18n/cy.ts
@@ -22,7 +22,6 @@ export const messages: Messages = {
   ccUpdateFailed: "Diweddaru cardyn",
   ccRegion: "Modd o dalu",
   ccEdit: "Addasu manylion cardyn.",
-  items: "Eitemau a gynwyswyd",
   receipt: "Derbyneb",
   failed: "Methodd",
   active: "Cyfredol",
@@ -44,6 +43,7 @@ export const messages: Messages = {
   updateNotification: "Diweddarwyd y danysgrifiad.",
   errorNotification:
     "Mae gwall anhysbys wedi digwydd. Rhowch gynnig arall arni yn nes ymlaen neu cysylltwch â ni am help..",
+  editItems: "Golygu",
 
   date: date => {
     return new Date(date).toLocaleDateString("cy", {
@@ -64,6 +64,8 @@ export const messages: Messages = {
       currency
     });
   },
+
+  items: length => `${length} eitem`,
 
   summary: items => {
     const { name } = [...items].sort((a, b) => a.price - b.price).pop();

--- a/src/components/subscription/i18n/en.ts
+++ b/src/components/subscription/i18n/en.ts
@@ -16,7 +16,6 @@ export const messages: Messages = {
   ccUpdateFailed: "Update card",
   ccRegion: "Payment method",
   ccEdit: "Edit card details.",
-  items: "Included items",
   receipt: "Receipt",
   failed: "Failed",
   active: "Active",
@@ -38,6 +37,7 @@ export const messages: Messages = {
   updateNotification: "Subscription updated.",
   errorNotification:
     "An unknown error has occurred. Please try again later or contact us for help.",
+  editItems: "Edit",
 
   date: date => {
     return new Date(date).toLocaleDateString("en", {
@@ -58,6 +58,8 @@ export const messages: Messages = {
       currency
     });
   },
+
+  items: length => `${length} ${length === 1 ? "item" : "items"}`,
 
   summary: items => {
     const { name } = [...items].sort((a, b) => a.price - b.price).pop();

--- a/src/components/subscription/i18n/fr.ts
+++ b/src/components/subscription/i18n/fr.ts
@@ -16,7 +16,6 @@ export const messages: Messages = {
   ccUpdateFailed: "Mise à jour carte",
   ccRegion: "Méthode de paiement",
   ccEdit: "Modifier informations de carte.",
-  items: "Articles ajoutés",
   receipt: "Reçu",
   failed: "Échoué",
   active: "Active",
@@ -38,6 +37,8 @@ export const messages: Messages = {
   updateNotification: "Abonnement mis à jour.",
   errorNotification:
     "Une erreur inconnue s'est produite. Veuillez réessayer plus tard ou contactez-nous pour obtenir de l'aide",
+  editItems: "Modifier",
+
   date: date => {
     return new Date(date).toLocaleDateString("fr", {
       month: "long",
@@ -57,6 +58,8 @@ export const messages: Messages = {
       currency
     });
   },
+
+  items: length => `${length} ${length === 1 ? "article" : "articles"}`,
 
   summary: items => {
     const { name } = [...items].sort((a, b) => a.price - b.price).pop();

--- a/src/components/subscription/i18n/pt-br.ts
+++ b/src/components/subscription/i18n/pt-br.ts
@@ -16,7 +16,6 @@ export const messages: Messages = {
   ccUpdateFailed: "Atualizar cartão",
   ccRegion: "Método de pagamento",
   ccEdit: "Editar detalhes do cartão.",
-  items: "Itens inclusos",
   receipt: "Recibo",
   failed: "Falhou",
   active: "Ativo",
@@ -38,6 +37,7 @@ export const messages: Messages = {
   updateNotification: "Subscrição atualizada",
   errorNotification:
     "Ocorreu um erro desconhecido. Por favor, tente novamente mais tarde ou contate-nos para obter ajuda.",
+  editItems: "Editar",
 
   date: date => {
     return new Date(date).toLocaleDateString("pt-br", {
@@ -58,6 +58,8 @@ export const messages: Messages = {
       currency
     });
   },
+
+  items: length => `${length} ${length === 1 ? "iteь" : "itens"}`,
 
   summary: items => {
     const { name } = [...items].sort((a, b) => a.price - b.price).pop();

--- a/src/components/subscription/i18n/ru.ts
+++ b/src/components/subscription/i18n/ru.ts
@@ -32,7 +32,6 @@ export const messages: Messages = {
   ccUpdateFailed: "Исправить проблему",
   ccEdit: "Изменить данные карты.",
   ccRegion: "Способ оплаты",
-  items: "Included items",
   receipt: "Показать чек",
   failed: "Ошибка платежа",
   active: "Успешный платеж",
@@ -53,6 +52,7 @@ export const messages: Messages = {
   updateNotification: "Подписка обновлена.",
   errorNotification:
     "Кажется, у нас что-то сломалось. Пожалуйста, попробуйте еще раз или напишите нам.",
+  editItems: "Изменить",
 
   date: date => {
     return new Date(date).toLocaleDateString("ru", {
@@ -73,6 +73,8 @@ export const messages: Messages = {
       currency
     });
   },
+
+  items: n => `${n} ${pluralize(n, "товара", "товаров", "товар")}`,
 
   summary: items => {
     const { name } = [...items].sort((a, b) => a.price - b.price).pop();

--- a/src/components/subscription/subscription.tsx
+++ b/src/components/subscription/subscription.tsx
@@ -333,13 +333,30 @@ export class Subscription implements Mixins {
                 />
               </div>
 
-              {this._template._embedded["fx:items"].map(item => (
-                <CartItem
-                  i18n={this.i18n}
-                  template={this._template}
-                  item={item}
-                />
-              ))}
+              <section>
+                <div class="flex items-center justify-between px-m mb-xs">
+                  <h1 class="text-s text-secondary">
+                    {this.i18n.items(
+                      this._template._embedded["fx:items"].length
+                    )}
+                  </h1>
+
+                  <Link
+                    size="s"
+                    href="/todo"
+                    text={this.i18n.editItems}
+                    color="primary"
+                  />
+                </div>
+
+                {this._template._embedded["fx:items"].map(item => (
+                  <CartItem
+                    i18n={this.i18n}
+                    template={this._template}
+                    item={item}
+                  />
+                ))}
+              </section>
 
               <div class="px-m">
                 {this._isNextDateEditable && (

--- a/src/components/subscription/subscription.tsx
+++ b/src/components/subscription/subscription.tsx
@@ -1,28 +1,26 @@
-import { Method, Element, Component, EventEmitter } from "@stencil/core";
-import { h, Prop, Watch, Event, State } from "@stencil/core";
-
-import { GetResponse, FullGetResponse } from "../../api";
-import { patch as updateSubscription } from "../../api/subscriptions";
-import { get as getCustomer } from "../../api";
-import { APIError } from "../../api/utils";
-
-import * as vaadin from "../../mixins/vaadin";
-import * as store from "../../mixins/store";
 import * as i18n from "../../mixins/i18n";
+import * as store from "../../mixins/store";
+import * as vaadin from "../../mixins/vaadin";
 
-import { Link } from "../Link";
-import { Summary } from "./partials/Summary";
-import { CartItem } from "./partials/CartItem";
-import { Transactions } from "./partials/Transactions";
+import { Component, Element, EventEmitter, Method } from "@stencil/core";
+import { Event, Prop, State, Watch, h } from "@stencil/core";
+import { FullGetResponse, GetResponse } from "../../api";
+
+import { APIError } from "../../api/utils";
 import { BillingDetails } from "./partials/BillingDetails";
-import { PaymentMethod } from "./partials/PaymentMethod";
-import { NextDatePicker } from "./partials/NextDatePicker";
-import { FrequencyPicker } from "./partials/FrequencyPicker";
-
-import { getParentPortal } from "../../assets/utils/getParentPortal";
+import { CartItem } from "./partials/CartItem";
 import { ErrorOverlay } from "../ErrorOverlay";
+import { FrequencyPicker } from "./partials/FrequencyPicker";
+import { Link } from "../Link";
+import { NextDatePicker } from "./partials/NextDatePicker";
+import { PaymentMethod } from "./partials/PaymentMethod";
+import { Summary } from "./partials/Summary";
+import { Transactions } from "./partials/Transactions";
 import { getCancelUrl } from "./utils";
+import { get as getCustomer } from "../../api";
+import { getParentPortal } from "../../assets/utils/getParentPortal";
 import { i18nProvider } from "./i18n";
+import { patch as updateSubscription } from "../../api/subscriptions";
 
 type StoreMixin = store.Mixin<
   GetResponse<{
@@ -275,6 +273,8 @@ export class Subscription implements Mixins {
   }
 
   render() {
+    const subModLink = this._subscription?._links["fx:sub_modification_url"];
+
     return (
       <details
         class="relative bg-base font-lumo overflow-hidden leading-s"
@@ -341,12 +341,14 @@ export class Subscription implements Mixins {
                     )}
                   </h1>
 
-                  <Link
-                    size="s"
-                    href="/todo"
-                    text={this.i18n.editItems}
-                    color="primary"
-                  />
+                  {subModLink && (
+                    <Link
+                      size="s"
+                      href={subModLink.href}
+                      text={this.i18n.editItems}
+                      color="primary"
+                    />
+                  )}
                 </div>
 
                 {this._template._embedded["fx:items"].map(item => (

--- a/src/components/subscription/subscription.tsx
+++ b/src/components/subscription/subscription.tsx
@@ -341,7 +341,7 @@ export class Subscription implements Mixins {
                     )}
                   </h1>
 
-                  {subModLink && (
+                  {subModLink && this._subscription?.is_active && (
                     <Link
                       size="s"
                       href={subModLink.href}

--- a/src/components/subscription/types.ts
+++ b/src/components/subscription/types.ts
@@ -47,9 +47,6 @@ export interface Messages {
   /** Credit card element group label. */
   ccRegion: string;
 
-  /** Included items region label. */
-  items: string;
-
   /** Transaction receipt link text. */
   receipt: string;
 
@@ -101,6 +98,9 @@ export interface Messages {
   /** Text of the link to the subscription cancellation page. */
   cancelSubscription: string;
 
+  /** Sub modify link text (if present). */
+  editItems: string;
+
   /** Any localized date in the component. */
   date: (date: Date | string) => string;
 
@@ -109,6 +109,9 @@ export interface Messages {
 
   /** Any localized price in the component. */
   price: (value: number, currency: string) => string;
+
+  /** Items section header including the number of items in a subscription. */
+  items: (length: number) => string;
 
   /** The top text summarizing the subscription. */
   summary: (items: Item[]) => string;


### PR DESCRIPTION
New functionality to pair the customer portal with the `foxy-items-form` in https://github.com/Foxy/foxy-elements, as seen here: https://elements.foxy.dev/?path=/story/integrations-items-form--minimal-slots-approach

Addition of an "Edit" link for subscriptions, like so:
![image](https://user-images.githubusercontent.com/34131/98771682-decedf00-2399-11eb-8aa4-a95344ae005d.png)