### PR TITLE
fix(customer-portal): router link target issue

### DIFF
--- a/src/components/customer-portal/customer-portal.tsx
+++ b/src/components/customer-portal/customer-portal.tsx
@@ -295,8 +295,8 @@ export class CustomerPortal
                   {this.router && Boolean(tab.href) ? (
                     <a
                       tabIndex={-1}
-                      target={!tab.isPortalLink && "_blank"}
-                      href={this.router && tab.href}
+                      target={tab.isPortalLink ? undefined : "_blank"}
+                      href={tab.href}
                       rel="nofollow noopener noreferrer"
                     >
                       {tab.text}


### PR DESCRIPTION
**Reported issue:**

> We’ve noticed a bug on the portal, where if the router options is enabled and a hash isn’t present the navigation tabs open in a new browser tab.

**Cause & Fix:**

An incorrect property binding in the portal renderer would resolve to `false` and then automatically be converted to string when used in the `target` attribute of `<a>`. Since unknown link targets are treated as `_blank`, this error would result in the behavior outlined above. The fix is to use an explicit ternary expression that picks one of two predefined values.