### PR TITLE
Fix FoxySignInElement validation issues

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,5 +1,5 @@
-import { Link } from "../assets/types/Link";
 import { GetResponse } from ".";
+import { Link } from "../assets/types/Link";
 
 export type Fields<T> = Omit<T, "_links" | "_embedded">;
 
@@ -92,7 +92,13 @@ export type JSONError = {
   code: string;
 
   /** Human-readable error message in English. */
-  message: string;
+  message:
+    | string
+    | {
+        message: string;
+        param: string;
+        value: string;
+      };
 };
 
 export class APIError extends Error implements JSONError {
@@ -100,7 +106,11 @@ export class APIError extends Error implements JSONError {
   code: string;
 
   constructor(response: JSONError) {
-    super(response.message);
+    super(
+      typeof response.message === "string"
+        ? response.message
+        : response.message.message
+    );
 
     this.type = response.type;
     this.code = response.code;

--- a/src/components/sign-in/sign-in.tsx
+++ b/src/components/sign-in/sign-in.tsx
@@ -1,3 +1,5 @@
+import { TextFieldElement } from "@vaadin/vaadin-text-field";
+
 import {
   Component,
   Element,
@@ -26,8 +28,8 @@ import { Skeleton } from "../Skeleton";
 })
 export class SignIn implements vaadin.Mixin, i18n.Mixin<typeof i18nProvider> {
   private formElement: HTMLFormElement;
-  private emailElement: HTMLInputElement;
-  private passwordElement: HTMLInputElement;
+  private emailElement: TextFieldElement;
+  private passwordElement: TextFieldElement;
 
   @State() i18nProvider = i18nProvider;
   @State() i18n: Messages | null = null;
@@ -126,7 +128,7 @@ export class SignIn implements vaadin.Mixin, i18n.Mixin<typeof i18nProvider> {
   }
 
   private requestSubmit(e?: Event) {
-    if (this.formElement.reportValidity()) {
+    if (!this.emailElement.invalid && !this.passwordElement.invalid) {
       this.handleSubmit(e);
     }
   }


### PR DESCRIPTION
This PR fixes the incorrect `[Object object]` error text that appears after submitting an empty form.