### PR TITLE
bugfix/navigation-click-area

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@foxy.io/customer-portal",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@foxy.io/customer-portal",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0-beta.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -4871,6 +4871,7 @@
         "yallist"
       ],
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -8348,6 +8349,7 @@
         "yallist"
       ],
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/components/customer-portal/customer-portal.tsx
+++ b/src/components/customer-portal/customer-portal.tsx
@@ -286,21 +286,19 @@ export class CustomerPortal
             <vaadin-tabs selected={this.tabIndex} data-theme="minimal centered">
               {this.extendedTabs.map((tab, index) => (
                 <vaadin-tab
+                  class="p-0"
                   data-e2e={`lnk-${tab.path}`}
                   onClick={() => !this.router && (this.tabIndex = index)}
                 >
-                  {this.router && Boolean(tab.href) ? (
-                    <a
-                      tabIndex={-1}
-                      target={tab.isPortalLink ? undefined : "_blank"}
-                      href={tab.href}
-                      rel="nofollow noopener noreferrer"
-                    >
-                      {tab.text}
-                    </a>
-                  ) : (
-                    tab.text
-                  )}
+                  <a
+                    tabIndex={-1}
+                    target={tab.isPortalLink ? "_self" : "_blank"}
+                    class="m-0"
+                    href={this.router ? tab.href : undefined}
+                    rel="nofollow noopener noreferrer"
+                  >
+                    {tab.text}
+                  </a>
                 </vaadin-tab>
               ))}
 


### PR DESCRIPTION
This PR fixes an issue that would appear when using the router built into Customer Portal: when clicking on a tab just outside of the tab label, the component would not perform navigation even though the selected tab would render active state. In this update the layout has been fixed to make sure that the child `<a>` of `<vaadin-tab>` covers the entire parent container.