### PR TITLE
build: re-enable es5 build

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -9,6 +9,7 @@ import cssnano from "cssnano";
 
 export const config: Config = {
   namespace: "foxy",
+  buildEs5: "prod",
   globalScript: "src/preflight.ts",
   testing: {
     browserArgs: ["--no-sandbox"]


### PR DESCRIPTION
This PR re-enables ES5 builds that were turned off by default in Stencil 2.0.