### PR TITLE
fix: allow null cc info

### DIFF
--- a/src/assets/schema/PaymentMethod.json
+++ b/src/assets/schema/PaymentMethod.json
@@ -15,22 +15,22 @@
         },
         "cc_type": {
           "description": "The credit card or debit card type. This will be determined automatically once the payment card is saved.",
-          "type": "string",
+          "type": ["string", "null"],
           "examples": ["Visa", "MasterCard", "Maestro", "Discovery", "JCB", "UnionPay"]
         },
         "cc_number_masked": {
           "description": "A masked version of this payment card showing only the last 4 digits.",
-          "type": "string",
+          "type": ["string", "null"],
           "faker": "finance.mask"
         },
         "cc_exp_month": {
           "description": "The payment card expiration month in the MM format.",
-          "type": "string",
+          "type": ["string", "null"],
           "pattern": "^(0[1-9])|(1[1-2])$"
         },
         "cc_exp_year": {
           "description": "The payment card expiration year in the YYYY format.",
-          "type": "string",
+          "type": ["string", "null"],
           "pattern": "^202[0-9]$"
         }
       },

--- a/src/assets/types/PaymentMethod.ts
+++ b/src/assets/types/PaymentMethod.ts
@@ -25,17 +25,17 @@ export type PaymentMethod = {
   /**
    * The credit card or debit card type. This will be determined automatically once the payment card is saved.
    */
-  cc_type: string;
+  cc_type: string | null;
   /**
    * A masked version of this payment card showing only the last 4 digits.
    */
-  cc_number_masked: string;
+  cc_number_masked: string | null;
   /**
    * The payment card expiration month in the MM format.
    */
-  cc_exp_month: string;
+  cc_exp_month: string | null;
   /**
    * The payment card expiration year in the YYYY format.
    */
-  cc_exp_year: string;
+  cc_exp_year: string | null;
 };

--- a/src/components/subscription/partials/PaymentMethod.tsx
+++ b/src/components/subscription/partials/PaymentMethod.tsx
@@ -34,13 +34,14 @@ const cover: Record<System, string> = {
 };
 
 function getLast4Digits(paymentMethod: DefaultPaymentMethod) {
+  if (paymentMethod.cc_number_masked === null) return "";
   return paymentMethod.cc_number_masked.substring(
     paymentMethod.cc_number_masked.length - 4
   );
 }
 
 function getSystem(paymentMethod: DefaultPaymentMethod) {
-  const system = paymentMethod.cc_type.toLowerCase();
+  const system = paymentMethod.cc_type?.toLowerCase() ?? "";
   return system in cover ? (system as System) : "unknown";
 }
 


### PR DESCRIPTION
Some payment method resources may have `null` in various fields, which the previous version of the portal didn't account for. As a result, the entire subscription element would fail to render. This PR corrects this behaviour.